### PR TITLE
Add optional filename overwrite

### DIFF
--- a/lib/upload.js
+++ b/lib/upload.js
@@ -29,10 +29,12 @@ module.exports = (url, config) => {
   });
   const upload = isBuffer ? conf.file :
     fs.createReadStream(path.resolve(process.cwd(), conf.file));
-  form.append('file1', upload, !isBuffer ? {} : {
+  const opt = !isBuffer ? {} : {
     contentType: conf.contentType,
     filename: conf.filename,
-  });
+  }
+  if (conf.filename) { opt.filename = conf.filename }
+  form.append('file1', upload, opt);
   delete conf.file;
 
   return request(url, 'GET', conf)


### PR DESCRIPTION
Hi there, thanks for this API wrapper!

I've made a quick patch to allow for custom filenames when using a file path instead of a buffer.

Would be great if you could merge and publish this change on npm, as I need it for my use-case. :)

Thanks!


